### PR TITLE
tests for auth endpoints

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = config.settings
+python_files = tests.py test_*.py tests_*.py *_test.py *_tests.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,4 @@ urllib3==2.0.2
 Pillow==9.5.0
 django-extra-fields==3.0.2
 django-cors-headers==4.0.0
+pytest-django==4.5.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,4 +12,5 @@ exclude =
     env/
 per-file-ignores =
     */settings.py:E501
+    pytest.ini:E999
 max-complexity = 10

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,96 @@
+from datetime import datetime
+
+import pytest
+
+from rest_framework.test import APIClient
+
+from users.models import CustomUser
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+# фикстура для создания пользователя (не авторизованного)
+@pytest.fixture
+def new_user_factory():
+    def create_user(
+            email: str,
+            password: str,
+            first_name: str = None,
+            last_name: str = None,
+            middle_name: str = None,
+            job_title: str = None,
+            personal_email: str = None,
+            corporate_phone_number: str = None,
+            personal_phone_number: str = None,
+            birthday_date: datetime = None,
+            bio: str = None,
+            photo: str = None,
+            is_staff: bool = False,
+            is_active: bool = True,
+    ):
+        user = CustomUser.objects.create(
+            email=email,
+            first_name=first_name,
+            last_name=last_name,
+            middle_name=middle_name,
+            job_title=job_title,
+            personal_email=personal_email,
+            corporate_phone_number=corporate_phone_number,
+            personal_phone_number=personal_phone_number,
+            birthday_date=birthday_date,
+            bio=bio,
+            photo=photo,
+            is_staff=is_staff,
+            is_active=is_active,
+        )
+        user.set_password(password)
+        user.save()
+        return user
+    return create_user
+
+
+# фикстура для создания авторизованного пользователя
+@pytest.fixture
+def authenticated_user_factory(new_user_factory, client):
+    def create_user(
+        email: str,
+        password: str,
+        first_name: str = None,
+        last_name: str = None,
+        middle_name: str = None,
+        job_title: str = None,
+        personal_email: str = None,
+        corporate_phone_number: str = None,
+        personal_phone_number: str = None,
+        birthday_date: datetime = None,
+        bio: str = None,
+        photo: str = None,
+        is_staff: bool = False,
+        is_active: bool = True,
+
+    ):
+        user = new_user_factory(
+            email=email,
+            password=password,
+            first_name=first_name,
+            last_name=last_name,
+            middle_name=middle_name,
+            job_title=job_title,
+            personal_email=personal_email,
+            corporate_phone_number=corporate_phone_number,
+            personal_phone_number=personal_phone_number,
+            birthday_date=birthday_date,
+            bio=bio,
+            photo=photo,
+            is_staff=is_staff,
+            is_active=is_active,
+        )
+        client.post(
+            '/api/v1/auth/token/login/',
+            {'password': password, 'email': user.email}
+        )
+        return user
+    return create_user

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,93 @@
+import pytest
+
+from rest_framework import status
+
+pytestmark = pytest.mark.django_db
+
+
+class TestAuthEndpoints:
+    path = '/api/v1/auth/token/'
+
+    @pytest.mark.parametrize(
+        'user_email, user_password, login_email, login_password, validity',
+        [
+            (
+                'test_user@mail.com', 'password',
+                'test_user@mail.com', 'password',
+                status.HTTP_200_OK
+            ),
+            (
+                'test_user@mail.com', 'password',
+                'test_user@mail.com', 'wrong_password',
+                status.HTTP_400_BAD_REQUEST
+            ),
+            (
+                'test_user@mail.com', 'password',
+                'wrong@mail.com', 'password',
+                status.HTTP_400_BAD_REQUEST
+            ),
+        ]
+    )
+    def test_login_user_post(
+        self, new_user_factory, client,
+        user_email, user_password, login_email, login_password, validity
+    ):
+        user = new_user_factory(email=user_email, password=user_password)
+        response = client.post(
+            f'{self.path}login/',
+            {'password': login_password, 'email': login_email}
+        )
+        assert response.status_code == validity
+        if response.status_code == status.HTTP_200_OK:
+            assert response.data['auth_token'] == user.auth_token.key
+
+    @pytest.mark.parametrize(
+        'email, password, is_authenticated, validity',
+        [
+            ('test@mail.com', 'password', True, status.HTTP_204_NO_CONTENT),
+            ('test@mail.com', 'password', False, status.HTTP_401_UNAUTHORIZED),
+        ]
+    )
+    def test_logout_user_post(
+        self, authenticated_user_factory, new_user_factory, client,
+        email, password, is_authenticated, validity,
+    ):
+        user = (
+            authenticated_user_factory(email=email, password=password)
+            if is_authenticated
+            else new_user_factory(email=email, password=password)
+        )
+        token = user.auth_token.key if is_authenticated else None
+        response = client.post(
+            f'{self.path}logout/',
+            HTTP_AUTHORIZATION=f'Token {token}'
+        )
+        assert response.status_code == validity
+
+
+class TestAddressbookEndpoints:
+    path = '/api/v1/addressbook'
+
+    def test_addressbook_get(self):
+        pass
+
+
+class TestUsersEndpoints:
+    path = '/api/v1/users/'
+
+    def test_users_get(self):
+        pass
+
+
+class TestPostsEndpoints:
+    path = 'api/v1/posts/'
+
+    def test_posts_get(self):
+        pass
+
+
+class TestBirthdayListEndpoints:
+    path = 'api/v1/birthday_list/'
+
+    def test_birthday_list_get(self):
+        pass


### PR DESCRIPTION
Добавил тесты эндпоинтов для авторизации auth/token/login и logout.
Конфигурационный файл для тестов – pytest.ini.  Там можно задать формат названия тестовых файлов, которые будут запускаться автоматически (python_files).
 
Тесты в папке tests:
conftest.py – сейчас содержит только фикстуры по созданию пользователя (без авторизации) и авторизованного пользователя, которые можно использовать в своих тестах.
test_endpoints.py – файл с тестами эндпоинтов. Пока только для авторизации.
 
Комментарии:
- В тесте logout при обращении к API возвращается код 204, поэтому я его и передавал в assert. Но в swagger вроде указан код успешного ответа 201, если не ошибаюсь.
- У меня тесты работали только когда запущен/развернут postgres. Без запущенной базы данных pytest выдавал ошибку.
