### PR TITLE
fix addressbook

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -184,7 +184,7 @@ class BirthdayList(ListAPIView):
 class AddressBookView(ListAPIView):
     """Create address book view."""
 
-    queryset = CustomUser.objects.all().order_by('last_name')
+    queryset = CustomUser.objects.all().order_by('last_name', 'id')
     serializer_class = AddressBookSerializer
     permission_classes = (IsAuthenticated,)
     pagination_class = AddressBookSetPagination


### PR DESCRIPTION
Добавил небольшие правки в адресную книгу, чтобы при пагинации контакты не дублировались.
Сейчас в адресной книге задано упорядочивание вывода контактов по полю 'фамилия'.
Поскольку в тестовом режиме многие заносят данные пользователей без указания фамилии, то скорее всего из-за этого происходит дублирование вывода контактов (т.к. сортировка получается рандомная).
Поэтому дополнительно добавил упорядочивание и по полю 'id', которое не нулевое для всех пользователей.